### PR TITLE
[codex] Add cross-platform desktop build action

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -78,7 +78,7 @@ jobs:
         run: npm run check
 
       - name: Build ${{ matrix.label }} package
-        run: npm run ${{ matrix.npm_script }}
+        run: npm run ${{ matrix.npm_script }} -- --publish never
 
       - name: List generated files
         shell: bash

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,0 +1,93 @@
+name: Build desktop artifacts
+
+on:
+  push:
+    branches:
+      - main
+      - "codex/**"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-desktop-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  package:
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    env:
+      CI: true
+      CSC_IDENTITY_AUTO_DISCOVERY: "false"
+      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
+      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Linux x64
+            runner: ubuntu-latest
+            npm_script: dist:linux
+            artifact_name: CodeSeeX-linux-x64
+            artifact_paths: |
+              dist/*.AppImage
+              dist/*.deb
+              dist/*.tar.gz
+              dist/*.yml
+              dist/*.blockmap
+          - label: macOS arm64
+            runner: macos-14
+            npm_script: dist:mac
+            artifact_name: CodeSeeX-macos-arm64
+            artifact_paths: |
+              dist/*.dmg
+              dist/*-mac.zip
+              dist/*.yml
+              dist/*.blockmap
+          - label: Windows x64
+            runner: windows-latest
+            npm_script: dist:win
+            artifact_name: CodeSeeX-windows-x64
+            artifact_paths: |
+              dist/*.exe
+              dist/*.yml
+              dist/*.blockmap
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check JavaScript syntax
+        run: npm run check
+
+      - name: Build ${{ matrix.label }} package
+        run: npm run ${{ matrix.npm_script }}
+
+      - name: List generated files
+        shell: bash
+        run: find dist -maxdepth 2 -type f -print | sort
+
+      - name: Upload ${{ matrix.label }} artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_paths }}
+          if-no-files-found: error
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ npm run dist:mac
 npm run dist:linux
 ```
 
+GitHub Actions can build the desktop artifacts automatically for Linux, macOS, and Windows. See [Desktop Build Action](docs/build-actions.md) for the workflow setup and testing steps.
+
 ## Privacy & License
 
 CodeSeeX is a local proxy, but model requests are forwarded to the configured DeepSeek API endpoint. Do not send code, secrets, personal data, or third-party material unless you have permission to process it with that service.

--- a/docs/build-actions.md
+++ b/docs/build-actions.md
@@ -1,0 +1,63 @@
+# Desktop Build Action
+
+CodeSeeX uses `.github/workflows/build-desktop.yml` to build runnable desktop artifacts on GitHub Actions.
+
+## When It Runs
+
+The workflow runs in five situations:
+
+- Pushes to `main`, so the default branch always has current artifacts.
+- Pushes to `codex/**`, so contributor build branches can be tested in a fork before opening a pull request.
+- Tag pushes matching `v*`, so release candidate builds can be produced from version tags.
+- Pull requests targeting `main`, so maintainers can see whether the packaging flow still works.
+- Manual `workflow_dispatch`, so a maintainer can run the packaging workflow on demand.
+
+## Build Matrix
+
+The workflow uses one matrix job with one entry per operating system:
+
+- `Linux x64` runs on `ubuntu-latest` and executes `npm run dist:linux`.
+- `macOS arm64` runs on `macos-14` and executes `npm run dist:mac`.
+- `Windows x64` runs on `windows-latest` and executes `npm run dist:win`.
+
+GitHub's hosted runner documentation currently lists `macos-14` as an arm64 macOS runner, so this workflow produces Apple Silicon macOS artifacts. Add a second macOS matrix entry on an Intel runner if an Intel build is required.
+
+## Step-By-Step Setup
+
+1. `actions/checkout@v6` checks out the repository source into the runner workspace.
+2. `actions/setup-node@v6` installs Node.js 22 and enables npm cache reuse based on `package-lock.json`.
+3. `npm ci` installs dependencies exactly from the lockfile for reproducible builds.
+4. `npm run check` runs the repository's syntax checks before packaging.
+5. `npm run dist:linux`, `npm run dist:mac`, or `npm run dist:win` runs according to the matrix entry.
+6. `find dist -maxdepth 2 -type f -print | sort` prints the generated files into the workflow log for quick inspection.
+7. `actions/upload-artifact@v6` uploads the generated packages from `dist` as workflow artifacts.
+
+The workflow sets `CSC_IDENTITY_AUTO_DISCOVERY=false` so electron-builder does not try to discover local signing identities on CI runners. The produced artifacts are suitable for CI validation and manual testing, but production macOS distribution still needs a Developer ID certificate and notarization setup.
+
+## Artifact Names
+
+Uploaded artifact groups are named by platform:
+
+- `CodeSeeX-linux-x64`
+- `CodeSeeX-macos-arm64`
+- `CodeSeeX-windows-x64`
+
+Each group contains the installable packages and electron-builder metadata files generated for that platform.
+
+## Testing In A Fork
+
+To test this workflow from a fork, push a branch under `codex/**`:
+
+```sh
+git switch -c codex/cross-platform-build-actions
+git push -u origin codex/cross-platform-build-actions
+```
+
+Then inspect the fork workflow run:
+
+```sh
+gh run list --repo Rain156/CodeSeeX --branch codex/cross-platform-build-actions --workflow build-desktop.yml
+gh run watch --repo Rain156/CodeSeeX <run-id>
+```
+
+When all matrix jobs pass, open a pull request from the fork branch to `TasteSteak/CodeSeeX:main`.

--- a/docs/build-actions.md
+++ b/docs/build-actions.md
@@ -28,11 +28,11 @@ GitHub's hosted runner documentation currently lists `macos-14` as an arm64 macO
 2. `actions/setup-node@v6` installs Node.js 22 and enables npm cache reuse based on `package-lock.json`.
 3. `npm ci` installs dependencies exactly from the lockfile for reproducible builds.
 4. `npm run check` runs the repository's syntax checks before packaging.
-5. `npm run dist:linux`, `npm run dist:mac`, or `npm run dist:win` runs according to the matrix entry.
+5. `npm run dist:linux -- --publish never`, `npm run dist:mac -- --publish never`, or `npm run dist:win -- --publish never` runs according to the matrix entry. The explicit publish mode keeps CI focused on producing downloadable artifacts instead of trying to publish a GitHub Release.
 6. `find dist -maxdepth 2 -type f -print | sort` prints the generated files into the workflow log for quick inspection.
 7. `actions/upload-artifact@v6` uploads the generated packages from `dist` as workflow artifacts.
 
-The workflow sets `CSC_IDENTITY_AUTO_DISCOVERY=false` so electron-builder does not try to discover local signing identities on CI runners. The produced artifacts are suitable for CI validation and manual testing, but production macOS distribution still needs a Developer ID certificate and notarization setup.
+The workflow sets `CSC_IDENTITY_AUTO_DISCOVERY=false` so electron-builder does not try to discover local signing identities on CI runners. It also passes `--publish never` to electron-builder because GitHub Actions sets CI environment variables that otherwise make electron-builder try to publish with `GH_TOKEN`. The produced artifacts are suitable for CI validation and manual testing, but production macOS distribution still needs a Developer ID certificate and notarization setup.
 
 ## Artifact Names
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "linux": {
       "icon": "src/manager/static/assets/icons/app.png",
       "category": "Development",
+      "maintainer": "TasteSteak <noreply@github.com>",
       "target": [
         "AppImage",
         "deb",


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that packages CodeSeeX on Linux, macOS, and Windows.
- Upload generated desktop packages as short-lived workflow artifacts.
- Document every workflow trigger, matrix entry, build step, and fork-testing command in `docs/build-actions.md`.
- Add a Linux maintainer field required by electron-builder when producing `.deb` packages.

## How the action is built
- `actions/checkout@v6` checks out the repository.
- `actions/setup-node@v6` installs Node.js 22 and enables npm lockfile caching.
- `npm ci` installs dependencies exactly from `package-lock.json`.
- `npm run check` runs the existing JavaScript syntax checks before packaging.
- The matrix runs `dist:linux`, `dist:mac`, or `dist:win` on the matching hosted runner.
- `--publish never` prevents electron-builder from trying to publish a GitHub Release during CI artifact builds.
- `actions/upload-artifact@v6` uploads the generated packages from `dist`.

## Fork validation
Tested on the fork before opening this PR:

- Repository: `Rain156/CodeSeeX`
- Branch: `codex/cross-platform-build-actions`
- Successful run: https://github.com/Rain156/CodeSeeX/actions/runs/26228855427
- Artifacts uploaded: `CodeSeeX-linux-x64`, `CodeSeeX-macos-arm64`, `CodeSeeX-windows-x64`

## Notes
The macOS artifact is built on `macos-14`, which is an Apple Silicon/arm64 GitHub-hosted runner. The CI artifacts are suitable for validation and manual testing; production macOS distribution still needs Developer ID signing and notarization setup.

## Checks
- `npm ci`
- `npm run check`
- `npm run dist:mac -- --publish never` locally on macOS
- GitHub Actions matrix on fork: Linux x64, macOS arm64, Windows x64